### PR TITLE
Add "immediate" flag to the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ heic2jpg supports the following command-line arguments:
 
 - `-dir`: Specifies the directory to watch for changes. By default, the script watches the user's home directory.
 - `-autodelete`: Enables automatic deletion (moves to trash [OS agnostic]) of HEIC files after successful conversion. By default, auto-deletion is disabled.
+- `-i / --immediate`: Triggers conversion of any existing HEIC files in the specified directory. By default, this is disabled.
 - `-reset`: Resets the configuration to default settings, using the user's home directory and disabling auto-deletion.
 
 To use these command-line arguments, run the script with the desired options. Here are some examples:
@@ -20,6 +21,9 @@ To use these command-line arguments, run the script with the desired options. He
 ```bash
 # Watch a specific directory and enable auto-deletion
 python3 heic2jpg.py -dir /path/to/directory -autodelete
+
+# Convert existing files and then watch the directory
+python3 heic2jpg.py -i -dir /path/to/directory
 
 # Reset the configuration to default settings
 python3 heic2jpg.py -reset

--- a/heic2jpg.py
+++ b/heic2jpg.py
@@ -7,25 +7,31 @@ import argparse
 import configparser
 import send2trash
 import logging
+import glob
 from watchdog.observers import Observer
 from watchdog.events import PatternMatchingEventHandler
 
 
 def get_config():
     config = configparser.ConfigParser()
-    config.read('heic2jpg.ini')
+    config.read("heic2jpg.ini")
 
     # Load previous settings or defaults
-    dir = config.get('Settings', 'dir', fallback=os.path.expanduser("~"))
-    autodelete = config.getboolean('Settings', 'autodelete', fallback=False)
+    dir = config.get("Settings", "dir", fallback=os.path.expanduser("~"))
+    autodelete = config.getboolean("Settings", "autodelete", fallback=False)
+    immediate = config.getboolean("Settings", "immediate", fallback=False)
 
-    return config, dir, autodelete
+    return config, dir, autodelete, immediate
 
 
-def update_config(config, dir, autodelete):
+def update_config(config, directory="~", autodelete=False, immediate=False):
     # Save settings
-    config['Settings'] = {'dir': dir, 'autodelete': str(autodelete)}
-    with open('heic2jpg.ini', 'w') as configfile:
+    config["Settings"] = {
+        "dir": directory,
+        "autodelete": str(autodelete),
+        "immediate": str(immediate)
+    }
+    with open("heic2jpg.ini", "w") as configfile:
         config.write(configfile)
 
 
@@ -33,27 +39,91 @@ def parse_arguments():
     # Def command-line arguments
     parser = argparse.ArgumentParser(description="Converts HEIC files to JPG")
     parser.add_argument("-dir", help="Directory to watch for changes")
-    parser.add_argument("-autodelete", action='store', choices=['true', 'false'], help="Automatically delete HEIC file after successful conversion")
-    parser.add_argument("-reset", action='store_true', help="Reset to default settings")
+    parser.add_argument("-i", "--immediate", action="store", choices=["true", "false"],
+                        help="Convert the existing HEIC files in the directory before starting the watcher")
+    parser.add_argument("-autodelete", action="store", choices=["true", "false"],
+                        help="Automatically delete HEIC file after successful conversion")
+    parser.add_argument("-reset", action="store_true", help="Reset to default settings")
 
     # Parse command-line arguments
     args = parser.parse_args()
 
     return args
-def reset_config(config):
-    # Reset settings to defaults
-    dir = os.path.expanduser("~")
-    autodelete = False
 
-    # Update configurations
-    update_config(config, dir, autodelete)
+
+def reset_config(config):
+    # Reset configurations to defaults
+    update_config(config)
+
+
+class ImageConverter:
+    def __init__(self, directory, logger, autodelete=False):
+        """
+        Initialize an ImageConverter instance.
+
+        :param directory: The directory containing HEIC files.
+        :type directory: str
+        :param logger: The logger object for logging messages.
+        :type logger: logging.Logger
+        :param autodelete: Whether to automatically delete HEIC files after conversion. Defaults to False.
+        :type autodelete: bool, optional
+        """
+        self.directory = directory
+        self.logger = logger
+        self.autodelete = autodelete
+
+    def convert_existing(self):
+        """
+        Converts existing HEIC files in the directory to JPG
+        """
+        self.logger.info(f"Converting existing HEIC files in {self.directory} to JPG...")
+        for file in glob.iglob(f"{self.directory}/**/*.[hH][eE][iI][cC]", recursive=True):
+            self.heic_to_jpg(file)
+
+    def heic_to_jpg(self, path):
+        """
+        Convert a HEIC file to JPG.
+
+        :param path: The path to the HEIC file to convert.
+        :type path: str
+        """
+        self.logger.info(f"Converting {path} to jpg...")
+        conversion = subprocess.run(["magick", "convert", path, f"{os.path.splitext(path)[0]}.jpg"])
+        self.logger.info(f"Conversion finished for {path}")
+
+        if self.autodelete and conversion.returncode == 0:
+            self.delete_file(path)
+
+    def delete_file(self, path):
+        """
+        Send a file to the trash.
+
+        :param path: The path to the file to delete.
+        :type path: str
+        """
+        max_retries = 10
+        delay = 0.5  # delay in seconds
+        for i in range(max_retries):
+            try:
+                time.sleep(delay)  # wait a bit before deleting
+                self.logger.info(f"Deleting original HEIC file: {path}")
+                send2trash.send2trash(path)
+                break  # if deletion was successful, break out of the loop
+            except Exception as e:
+                if i < max_retries - 1:  # if this wasn't the last attempt
+                    self.logger.warning(
+                        f"Error deleting file {path}, retrying in {delay} seconds. Error was {e}")
+                    time.sleep(delay)  # wait a bit before retrying
+                else:
+                    self.logger.error(f"Error deleting file {path}, giving up. Error was {e}")
+
 
 class FileHandler(PatternMatchingEventHandler):
     patterns = ["*.heic", "*.jpg"]
 
-    def __init__(self, autodelete, logger, *args, **kwargs):
+    def __init__(self, image_converter, logger, *args, **kwargs):
         super(FileHandler, self).__init__(*args, **kwargs)
-        self.autodelete = autodelete
+        self.image_converter = image_converter
         self.logger = logger
 
     def process(self, event):
@@ -64,33 +134,8 @@ class FileHandler(PatternMatchingEventHandler):
             self.logger.info(f"Ignoring event in trash: {event.src_path}")
             return
 
-        if event.event_type == 'created' and event.src_path.lower().endswith(".heic"):
-            self.convert_heic_to_jpg(event)
-
-    def convert_heic_to_jpg(self, event):
-        # If a .heic file has been created or modified, convert it to .jpg
-        self.logger.info(f"Converting {event.src_path} to jpg...")
-        conversion = subprocess.run(['magick', 'convert', event.src_path, f'{os.path.splitext(event.src_path)[0]}.jpg'])
-        self.logger.info(f"Conversion finished for {event.src_path}")
-
-        if self.autodelete and conversion.returncode == 0:
-            self.delete_file(event)
-
-    def delete_file(self, event):
-        MAX_RETRIES = 10
-        DELAY = 0.5  # delay in seconds
-        for i in range(MAX_RETRIES):
-            try:
-                time.sleep(DELAY)  # wait a bit before deleting
-                self.logger.info(f"Deleting original HEIC file: {event.src_path}")
-                send2trash.send2trash(event.src_path)
-                break  # if deletion was successful, break out of the loop
-            except Exception as e:
-                if i < MAX_RETRIES - 1:  # if this wasn't the last attempt
-                    self.logger.warning(f"Error deleting file {event.src_path}, retrying in {DELAY} seconds. Error was {e}")
-                    time.sleep(DELAY)  # wait a bit before retrying
-                else:
-                    self.logger.error(f"Error deleting file {event.src_path}, giving up. Error was {e}")
+        if event.event_type == "created" and event.src_path.lower().endswith(".heic"):
+            self.image_converter.heic_to_jpg(event.src_path)
 
     def on_modified(self, event):
         self.process(event)
@@ -104,7 +149,7 @@ def setup_logger(log_file=None):
     logger.setLevel(logging.INFO)  # Or DEBUG, ERROR, etc.
 
     # Create formatter
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
     # Create console handler
     console_handler = logging.StreamHandler()
@@ -124,7 +169,7 @@ def main():
     args = parse_arguments()
 
     # Load configurations
-    config, dir, autodelete = get_config()
+    config, directory, autodelete, immediate = get_config()
 
     # If -reset flag is provided, reset the configuration and exit
     if args.reset:
@@ -134,21 +179,30 @@ def main():
 
     # If -dir argument is specified, update setting
     if args.dir:
-        dir = args.dir
+        directory = args.dir
 
     # If -autodelete argument is given, update setting
     if args.autodelete is not None:
-        autodelete = args.autodelete.lower() == 'true'
+        autodelete = args.autodelete.lower() == "true"
+
+    # If -immediate argument is given, update setting
+    if args.immediate is not None:
+        immediate = args.immediate.lower() == "true"
 
     # Update configurations
-    update_config(config, dir, autodelete)
+    update_config(config, directory, autodelete, immediate)
 
-    logger = setup_logger(log_file='heic2jpg.log')
+    logger = setup_logger(log_file="heic2jpg.log")
+    path = os.path.abspath(directory)
 
-    logger.info(f"Script started. Watching directory: {os.path.abspath(dir)}")
+    image_converter = ImageConverter(path, logger, autodelete=autodelete)
+    if immediate:
+        image_converter.convert_existing()
 
+    logger.info(f"Watching directory: {path}")
     observer = Observer()
-    observer.schedule(FileHandler(autodelete=autodelete, logger=logger), dir, recursive=True)
+    handler = FileHandler(image_converter, logger=logger)
+    observer.schedule(handler, directory, recursive=True)
     observer.start()
 
     try:


### PR DESCRIPTION
I saw this, found it useful, and then noticed that it wasn't converting the heic files _already_ in the directory at which I pointed this script. 

This allows the user to convert existing files in the directory before starting to watch the directory. As is, it begins watching the directory, but doesn't allow the user to convert what's already there unless you move it out and back in.

I also ["picked a rule and stuck with it"](https://peps.python.org/pep-0008/#string-quotes) when it comes to string quotes. 